### PR TITLE
Improve comment on INSTALLED_APPS ordering

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -22,8 +22,10 @@ INSTALLED_APPS = (
     'TODO_PACKAGE_NAME',
     'TODO_PACKAGE_NAME.tests',
 
-    # Put contenttypes before auth to work around test issue.
+    # Work around 'relation does not exist' errors by ordering the installed apps:
+    #   contenttypes -> auth -> everything else.
     # See: https://code.djangoproject.com/ticket/10827#comment:12
+    #      http://stackoverflow.com/q/29689365
     'django.contrib.contenttypes',
     'django.contrib.auth',
     'django.contrib.admin',


### PR DESCRIPTION
Looks like there's more to this error - I think there are actually two bugs here, not one - so I've updated the comment.  Both appear to be bugs or design flaws in Django, so I don't think we can do much about it other than this (painless) workaround, but the comment is worthwhile so we don't lose track of why.  

@incuna/backend Review/merge please? :)
